### PR TITLE
hotfix : MySQL Dialect 설정을 위한 hibernate.dialect 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="c75c33eb-8b33-40dd-aa40-6f7c51977112" name="Changes" comment="" />
+    <list default="true" id="c75c33eb-8b33-40dd-aa40-6f7c51977112" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/miniMall_BE/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/miniMall_BE/src/main/resources/application.properties" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -64,7 +67,7 @@
   &quot;keyToString&quot;: {
     &quot;Gradle.miniMall_BE [:com.tomjerry.miniMall.MiniMallApplication.main()].executor&quot;: &quot;Run&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/users/eojin&quot;,
     &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
     &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
     &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
@@ -74,6 +77,11 @@
 }</component>
   <component name="RunManager">
     <configuration name="MiniMallApplication" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
+      <envs>
+        <env name="DS_PASSWORD" value="zeare528!" />
+        <env name="DS_URL" value="jdbc:mysql://localhost:3306/miniMall" />
+        <env name="DS_USERNAME" value="root" />
+      </envs>
       <option name="MAIN_CLASS_NAME" value="com.tomjerry.miniMall.MiniMallApplication" />
       <module name="com.tomjerry.miniMall.main" />
       <extension name="coverage">

--- a/miniMall_BE/src/main/resources/application.properties
+++ b/miniMall_BE/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=miniMall
 
-# DS_PASSWORD=root1234!!;DS_URL=jdbc:mysql://localhost:3306/miniMall;DS_USERNAME=root
 spring.datasource.url=${DS_URL}
 spring.datasource.username=${DS_USERNAME}
 spring.datasource.password=${DS_PASSWORD}
@@ -11,13 +10,8 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
-
-spring.servlet.multipart.enabled=true
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
-
-spring.jpa.properties.hibernate.transaction.jta.platform=org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 아래와 같이 한다. -->
<!-- Type: 키워드 - 이슈 제목 (Issue #None) -->
<!-- 반드시 .github 내부에 파일을 둘 것 -->

## 관련 이슈

* 관련 이슈 (EX. #3)

<br>

## 변경 사항
<!--코드 변경 이유까지 작성할 것-->
<!--관련 스크린샷이 있다면 첨부할 것-->

- Spring Boot와 MySQL연동 시 발생한 오류

  - Caused by: org.hibernate.HibernateException: Unable to determine Dialect without JDBC metadata (please set 'jakarta.persistence.jdbc.url' for common cases or 'hibernate.dialect' when a custom Dialect implementation must be provided)
  
  - 원인 : Spring Boot 컨테이너가 MySQL Dialect 설정을 못 찾았기 때문
  
  - 해결 : application.properties에 코드 추가
    ```
    spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
    ```
